### PR TITLE
Fix creating directory with name that is already conforms to 8DOT3

### DIFF
--- a/pyfatfs/PyFatFS.py
+++ b/pyfatfs/PyFatFS.py
@@ -287,7 +287,7 @@ class PyFatFS(FS):
 
         # Create LFN entry if required
         _sfn = short_name.get_unpadded_filename()
-        if _sfn != dirname.upper() or self.preserve_case:
+        if _sfn != dirname.upper() or (_sfn != dirname and self.preserve_case):
             lfn_entry = make_lfn_entry(dirname, short_name)
             newdir.set_lfn_entry(lfn_entry)
 


### PR DESCRIPTION
when using preserve_case, fs.makedir("TEST") fails with:
```
File "C:\Python37\lib\site-packages\pyfatfs\PyFatFS.py", line 291, in makedir
lfn_entry = make_lfn_entry(dirname, short_name)
File "C:\Python37\lib\site-packages\pyfatfs\FATDirectoryEntry.py", line 609, in make_lfn_entry
errno=errno.EINVAL)
pyfatfs._exceptions.PyFATException: Directory entry is already 8.3 conform, no need to create an LFN entry.
```

The current check for this case was already in the function create (for files). So I copied it to makedir too.