### PR TITLE
Fix bug in parsing LFNs when opening multiple file systems

### DIFF
--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -632,8 +632,11 @@ class PyFat(object):
                                      address: int = 0,
                                      max_address: int = 0,
                                      tmp_lfn_entry: FATLongDirectoryEntry =
-                                     FATLongDirectoryEntry()):
+                                     None):
         """Parse directory entries in address range."""
+        if tmp_lfn_entry is None:
+            tmp_lfn_entry = FATLongDirectoryEntry()
+
         dir_hdr_size = FATDirectoryEntry.FAT_DIRECTORY_HEADER_SIZE
 
         if max_address == 0:

--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -648,6 +648,7 @@ class PyFat(object):
             # Parse each entry
             dir_hdr = self.__parse_dir_entry(hdr_addr)
             dir_sn = EightDotThree(encoding=self.encoding)
+            dir_first_byte = dir_hdr["DIR_Name"][0]
             try:
                 dir_sn.set_byte_name(dir_hdr["DIR_Name"])
             except NotAFatEntryException as ex:
@@ -663,7 +664,7 @@ class PyFat(object):
                 dir_hdr["DIR_Name"] = dir_sn
 
             # Long File Names
-            if FATLongDirectoryEntry.is_lfn_entry(dir_hdr["DIR_Name"],
+            if FATLongDirectoryEntry.is_lfn_entry(dir_first_byte,
                                                   dir_hdr["DIR_Attr"]):
                 self.parse_lfn_entry(tmp_lfn_entry, hdr_addr)
                 continue


### PR DESCRIPTION
The argument for tmp_lfn_entry is initialized to a global of FATLongDirectoryEntry object. So multiple filesystems objects are going to use the same tmp_lfn_entry when calling _fat12_parse_root_dir, which in some cases cause a failure in add_lfn_entry because tmp_lfn_entry.lfn_entries may be already populated with that ordinance.

I also changed the argument to is_lfn_entry to the correct one. It doesn't fix any bad behavior, because that byte was already checked before.