### PR TITLE
Optimize sequential I/O with big files + small bug fixes in writing/allocating clusters

### DIFF
--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -454,7 +454,7 @@ class PyFat(object):
         # Fill list of found free clusters
         free_clusters = []
         for i, _ in enumerate(self.fat):
-            if min_clus > i > max_clus:
+            if min_clus > i or i > max_clus:
                 # Ignore out of bound entries
                 continue
 

--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -385,6 +385,8 @@ class PyFat(object):
         for c in self.get_cluster_chain(cluster):
             cluster_sz += self.bytes_per_cluster
             last_cluster = c
+            if cluster_sz >= data_sz:
+                break
 
         if data_sz > cluster_sz:
             if extend_cluster is False:
@@ -409,6 +411,8 @@ class PyFat(object):
             t = bytes_written
             bytes_written += self.bytes_per_cluster
             self._write_data_to_address(data[t:bytes_written], b)
+            if bytes_written >= len(data):
+                break
 
     @_init_check
     @_readonly_check

--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -398,7 +398,7 @@ class PyFat(object):
 
         # Fill rest of data with zeroes if erase is set to True
         if erase:
-            new_sz = math.ceil(max(1, data_sz // self.bytes_per_cluster))
+            new_sz = max(1, math.ceil(data_sz / self.bytes_per_cluster))
             new_sz *= self.bytes_per_cluster
             data += b'\0' * (new_sz - data_sz)
 


### PR DESCRIPTION
When writing a big file in small chunks, the write is getting slower and slower because of few locations that iterate on all the chunks from the beginning every time.

I optimized the seek function in FatIO (when seeking forward), write_data_to_cluster, and  write_data_to_cluster (by caching the first free cluster)

Now writing 500MB in 0x4000 chunks takes few seconds instead of few minutes.