### PR TITLE
Fix multi partition mkfs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased_
 -----------
 
+Fixed
+-----
+
+* (mkfs) Handle offset correct in case of multiple partitions.
+
 1.0.0_ - 2022-02-03
 -------------------
 

--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -1055,7 +1055,7 @@ class PyFat(object):
             size = self.__fp_offset - self.__fp.seek(-1)
 
         try:
-            self.__fp.truncate(size)
+            self.__fp.truncate(size + self.__fp_offset)
         except IOError:
             raise PyFATException("Failed to truncate file to given size. "
                                  "Most likely the file can't be extended.",
@@ -1217,9 +1217,6 @@ class PyFat(object):
 
         self.__seek(len(self.bpb_header))
         self.__fp.write(boot_code)
-        # ensure boot loader code is not too big
-        if self.__fp.tell() > 510:
-            raise PyFATException("Boot code to large.")
 
         if fat_type == PyFat.FAT_TYPE_FAT32:
             free_count = (total_sectors_32 - rsvd_sec_cnt -


### PR DESCRIPTION
mkfs does not handle the offset correct in case of having multiple partitions. I removed the boot code length check as the boot code is fix anyhow.