### PR TITLE
FatIO: don't flush files on close if not open for writing

### DIFF
--- a/pyfatfs/FatIO.py
+++ b/pyfatfs/FatIO.py
@@ -112,7 +112,8 @@ class FatIO(io.RawIOBase):
     def close(self) -> None:
         """Close open file handles assuming lock handle."""
         self.seek(0)
-        self.fs.flush_fat()
+        if self.mode.writing:
+            self.fs.flush_fat()
         super().close()
 
     def readable(self) -> bool:


### PR DESCRIPTION
Otherwise, you can never close a file on a read-only file system: the flush call will bomb out with a read-only error.