### PR TITLE
Support FAT12 sectors larger than 512 bytes

### DIFF
--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -1096,7 +1096,9 @@ class PyFat(object):
                 (4194304, 64)   # disks up to   2   GB, 32k cluster
             ],
             PyFat.FAT_TYPE_FAT12: [
-                (32768, 64)
+                (4084, 1),      # disks up to   2   MB, .5k cluster
+                (8168, 2),      # disks up to   4   MB,  1k cluster
+                (16336, 4)      # disks up to   8   MB,  2k cluster
             ]
         }
         sec_per_clus = 0
@@ -1134,7 +1136,10 @@ class PyFat(object):
         elif fat_type == PyFat.FAT_TYPE_FAT16:
             root_ent_cnt = 512
         else:
-            root_ent_cnt = 224  # randomly picked, fine if sector_size is 512
+            if sector_size == 512:
+                root_ent_cnt = 224  # Floppy typical
+            else:
+                root_ent_cnt = 512
 
         rsvd_sec_cnt = 32 if fat_type == PyFat.FAT_TYPE_FAT32 else 1
 


### PR DESCRIPTION
In the mkfs function, the FAT12 cluster size of 64 sectors limits FAT12 implementations to 512-byte sectors only.
This change introduces a new table while maintaining the 4084-cluster limit for FAT12 prescribed by fatgen103.