### PR TITLE
Restore original iterator for non-lazy load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 * Discard unknown PyFilesystem2 opener arguments, do not pass through to underlying PyFatFS constructor
 * Lazy load directory entries for performance and `regex2fat <https://github.com/8051Enthusiast/regex2fat>`_ compatibility
    - Introduce ``lazy_load`` parameter to allow restoring previous behavior
+   - `PR #32 <https://github.com/nathanhi/pyfatfs/pull/32>`_: Fix tree iteration on non-lazy load by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 
 1.0.5_ - 2022-04-16
 -------------------

--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -761,7 +761,9 @@ class PyFat(object):
             if not self.lazy_load:
                 if dir_entry.is_directory() and not dir_entry.is_special():
                     # Iterate all subdirectories except for dot and dotdot
-                    for d in dir_entry.get_entries()[0]:
+                    cluster = dir_entry.get_cluster()
+                    subdirs = self.parse_dir_entries_in_cluster_chain(cluster)
+                    for d in subdirs:
                         dir_entry.add_subdirectory(d)
 
             # Reset temporary LFN entry

--- a/tests/test_PyFatFS.py
+++ b/tests/test_PyFatFS.py
@@ -59,11 +59,18 @@ class TestPyFatFS16(FSTestCases, TestCase):
             fs1.touch(os.path.join(d, "This requires an LFN entry.TxT"))
             fs1.touch(os.path.join(d, "FILE2.TXT"))
 
-        dentries = list(fs1.walk("/"))
+        dentries_fs1_initial = list(fs1.walk("/"))
+        fs1.fs.flush_fat()
+        in_memory_fs.seek(0)
+        in_memory_fs = BytesIO(in_memory_fs.read())
+        fs1 = PyFatBytesIOFS(in_memory_fs, encoding='UTF-8', lazy_load=False)
+        dentries_fs1_reopen = list(fs1.walk("/"))
+        assert dentries_fs1_initial == dentries_fs1_reopen
+
         in_memory_fs.seek(0)
         fs2 = PyFatBytesIOFS(BytesIO(in_memory_fs.read()),
                              encoding='UTF-8', lazy_load=True)
-        assert dentries == list(fs2.walk("/"))
+        assert dentries_fs1_reopen == list(fs2.walk("/"))
         fs1.close()
         fs2.close()
 


### PR DESCRIPTION
The modified iterator causes failure of FileSystem.tree() and copy_dir() APIs, possibly more.