### PR TITLE
Fix directory handling issues under lazy loading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
    - Introduce ``lazy_load`` parameter to allow restoring previous behavior
    - `PR #32 <https://github.com/nathanhi/pyfatfs/pull/32>`_: Fix tree iteration on non-lazy load by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
    - `PR #33 <https://github.com/nathanhi/pyfatfs/pull/33>`_: Fix missing parent directory entry link on lazy-load by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
+   - `PR #33 <https://github.com/nathanhi/pyfatfs/pull/33>`_: Do not re-populate directory structure from disk on pending entry change by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 
 Removed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 * Lazy load directory entries for performance and `regex2fat <https://github.com/8051Enthusiast/regex2fat>`_ compatibility
    - Introduce ``lazy_load`` parameter to allow restoring previous behavior
    - `PR #32 <https://github.com/nathanhi/pyfatfs/pull/32>`_: Fix tree iteration on non-lazy load by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
+   - `PR #33 <https://github.com/nathanhi/pyfatfs/pull/33>`_: Fix missing parent directory entry link on lazy-load by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 
 Removed
 ~~~~~~~

--- a/pyfatfs/FATDirectoryEntry.py
+++ b/pyfatfs/FATDirectoryEntry.py
@@ -376,6 +376,8 @@ class FATDirectoryEntry:
 
         clus = self.get_cluster()
         self.__dirs = self.__fs.parse_dir_entries_in_cluster_chain(clus)
+        for dir_entry in self.__dirs:
+            dir_entry._add_parent(self)
 
     def _get_entries_raw(self):
         """Get a full list of entries in current directory."""

--- a/pyfatfs/FATDirectoryEntry.py
+++ b/pyfatfs/FATDirectoryEntry.py
@@ -378,6 +378,7 @@ class FATDirectoryEntry:
         self.__dirs = self.__fs.parse_dir_entries_in_cluster_chain(clus)
         for dir_entry in self.__dirs:
             dir_entry._add_parent(self)
+        self.__lazy_load = False
 
     def _get_entries_raw(self):
         """Get a full list of entries in current directory."""
@@ -497,8 +498,6 @@ class FATDirectoryEntry:
         **NOTE:** This will also remove special entries such
         as ».«, »..« and volume labels!
         """
-        self._verify_is_directory()
-        self.__populate_dirs()
         # Iterate all entries
         for dir_entry in self._get_entries_raw():
             sn = dir_entry.get_short_name()


### PR DESCRIPTION
- Set the parent directory during populate_dirs (this is done in add_subdirectory() for non-lazy loading)
- Don't repopulate the directory structure from disk when there is a pending entry change