### PR TITLE
on value error 0..59, convert to 59 for seconds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Added
 * (mkfs) `PR #30 <https://github.com/nathanhi/pyfatfs/pull/30>`_: Add support for different FAT12 cluster sizes for filesystems up to 256MB by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 * `PR #36 <https://github.com/nathanhi/pyfatfs/pull/36>`_: Add Python 3.12 support by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 
+Fixed
+~~~~~
+
+* `#34 <https://github.com/nathanhi/pyfatfs/issues/34>`_ (DosDateTime) `PR #35 <https://github.com/nathanhi/pyfatfs/pull/35>`_: Gracefully handle invalid file timestamps by `@beckerben <https://github.com/beckerben>`_
+
 Changed
 ~~~~~~~
 

--- a/pyfatfs/DosDateTime.py
+++ b/pyfatfs/DosDateTime.py
@@ -47,4 +47,8 @@ class DosDateTime(datetime):
         second = (tm & (1 << 5) - 1) * 2
         minute = (tm >> 5) & ((1 << 6) - 1)
         hour = (tm >> 11) & ((1 << 5) - 1)
-        return time(hour, minute, second)
+
+        try:
+            return time(hour, minute, second)
+        except ValueError:
+            return time(0, 0, 0)

--- a/tests/test_DosDateTime.py
+++ b/tests/test_DosDateTime.py
@@ -4,8 +4,6 @@
 
 from datetime import datetime, time
 
-import pytest
-
 from pyfatfs.DosDateTime import DosDateTime
 
 
@@ -93,9 +91,8 @@ def test_deserialize_max():
 
 
 def test_deserialize_exceed_max():
-    """Deserialize invalid time value."""
-    with pytest.raises(ValueError, match="second must be in 0..59"):
-        DosDateTime.deserialize_time(0xBF7E)
+    """Deserialize invalid time value to 00:00:00."""
+    assert DosDateTime.deserialize_time(0xBF7E) == time(0, 0, 0)
 
 
 def test_deserialize_minutes_high():


### PR DESCRIPTION
Fix for issue #34 

This commit adds error handling for the exception whenever a second of "0" is encountered, this will force the second be returned to "59" in the time object rather than triggering an unhandled error.