### PR TITLE
Add Python 3.12 compatibility, drop Python 3.7 (EOL)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         # https://bugs.python.org/issue43749
         exclude:
-        - os: windows-latest
-          python-version: 3.7
         - os: windows-latest
           python-version: 3.8
 
@@ -51,10 +49,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install dependencies
         run: |
           make venv

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased_
 Added
 ~~~~~
 * (mkfs) `PR #30 <https://github.com/nathanhi/pyfatfs/pull/30>`_: Add support for different FAT12 cluster sizes for filesystems up to 256MB by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
+* `PR #36 <https://github.com/nathanhi/pyfatfs/pull/36>`_: Add Python 3.12 support by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 
 Changed
 ~~~~~~~
@@ -22,6 +23,11 @@ Changed
 * Lazy load directory entries for performance and `regex2fat <https://github.com/8051Enthusiast/regex2fat>`_ compatibility
    - Introduce ``lazy_load`` parameter to allow restoring previous behavior
    - `PR #32 <https://github.com/nathanhi/pyfatfs/pull/32>`_: Fix tree iteration on non-lazy load by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
+
+Removed
+~~~~~~~
+
+* `PR #36 <https://github.com/nathanhi/pyfatfs/pull/36>`_: Drop Python 3.7 support by `@zurcher <https://github.com/zurcher>`_ / `@Microsoft <https://github.com/Microsoft>`_
 
 1.0.5_ - 2022-04-16
 -------------------

--- a/pyfatfs/EightDotThree.py
+++ b/pyfatfs/EightDotThree.py
@@ -75,7 +75,7 @@ class EightDotThree:
         :param name: `bytes`: Padded (must be 11 bytes) 8dot3 name
         """
         if not isinstance(name, bytes):
-            raise TypeError(f"Given parameter must be of type bytes,"
+            raise TypeError(f"Given parameter must be of type bytes, "
                             f"but got {type(name)} instead.")
 
         name = bytearray(name)
@@ -94,7 +94,7 @@ class EightDotThree:
     def set_str_name(self, name: str):
         """Set the name as string from user input (i.e. folder creation)."""
         if not isinstance(name, str):
-            raise TypeError(f"Given parameter must be of type str,"
+            raise TypeError(f"Given parameter must be of type str, "
                             f"but got {type(name)} instead.")
 
         if not self.is_8dot3_conform(name, self.encoding):

--- a/pyfatfs/FatIO.py
+++ b/pyfatfs/FatIO.py
@@ -57,10 +57,10 @@ class FatIO(io.RawIOBase):
 
         ex: <FatFile fs=<PyFat object> path="/README.txt" mode="r">
         """
-        return f'<{self.__class__.__name__} ' \
-               f'fs={self.fs} ' \
-               f'path="{self.name}" ' \
-               f'mode="{self.mode}"'
+        return str(f'<{self.__class__.__name__} '
+                   f'fs={self.fs} '
+                   f'path="{self.name}" '
+                   f'mode="{self.mode}"')
 
     def seek(self, offset: int, whence: int = 0) -> int:
         """Seek to a given offset in the file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools ~= 65.6", "setuptools_scm[toml] ~= 7.1"]
+requires = ["setuptools ~= 67.8", "setuptools_scm[toml] ~= 7.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -46,7 +46,7 @@ development = [
     "coveralls>=3.0.0,<4.0.0",
     "flake8~=5.0",
     "flake8-docstrings>=1.6.0,<2.0.0",
-    "pip-tools>=6.12.0,<7.0.0",
+    "pip-tools~=7.3.0",
     "sphinx>=4.0.3,<4.1.0",
     "build~=0.9",
 ]

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -69,7 +69,7 @@ packaging==22.0
     #   sphinx
 pep517==0.13.0
     # via build
-pip-tools==6.12.1
+pip-tools==7.3.0
     # via pyfatfs (pyproject.toml)
 pluggy==1.0.0
     # via pytest

--- a/tests/test_PyFatFS.py
+++ b/tests/test_PyFatFS.py
@@ -36,7 +36,17 @@ def _make_fs(fat_type: int, **kwargs) -> (PyFatBytesIOFS, BytesIO):
             in_memory_fs)
 
 
-class TestPyFatFS16(FSTestCases, TestCase):
+class PyFsCompatLayer:
+    """PyFilesystem2 Python 3.12 compatibility layer.
+
+    Adds a workaround for PyFilesystem2#568:
+    https://github.com/PyFilesystem/pyfilesystem2/issues/568
+    """
+
+    assertRaisesRegexp = TestCase.assertRaisesRegex
+
+
+class TestPyFatFS16(FSTestCases, TestCase, PyFsCompatLayer):
     """Integration tests with PyFilesystem2 for FAT16."""
 
     FAT_TYPE = PyFat.FAT_TYPE_FAT16
@@ -107,13 +117,13 @@ class TestPyFatFS16(FSTestCases, TestCase):
         assert self.fs.readtext(fname) == '1' * 16
 
 
-class TestPyFatFS32(TestPyFatFS16, FSTestCases, TestCase):
+class TestPyFatFS32(TestPyFatFS16, FSTestCases, TestCase, PyFsCompatLayer):
     """Integration tests with PyFilesystem2 for FAT32."""
 
     FAT_TYPE = PyFat.FAT_TYPE_FAT32
 
 
-class TestPyFatFS12(TestPyFatFS16, FSTestCases, TestCase):
+class TestPyFatFS12(TestPyFatFS16, FSTestCases, TestCase, PyFsCompatLayer):
     """Test specifics of FAT12 filesystem."""
 
     FAT_TYPE = PyFat.FAT_TYPE_FAT12


### PR DESCRIPTION
This solves the following error when installing from source with `pip install -e`:

`AttributeError: module 'pkgutil' has no attribute 'ImpImporter'.`

Tested with Python 3.12 and 3.10.11.